### PR TITLE
feat: finalize local reusable actions with config-driven naming

### DIFF
--- a/.github/workflows/oidc-validate.yaml
+++ b/.github/workflows/oidc-validate.yaml
@@ -20,8 +20,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: AWS + Azure OIDC Login (org-wide)
-        uses: msdp-platform/actions/cloud-login@v1
+      - name: AWS + Azure OIDC Login (local)
+        uses: ./.github/actions/cloud-login
         with:
           aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: eu-west-1


### PR DESCRIPTION
- Update terraform-backend to use explicit inputs (no config file reading)
- Add naming config to globals.yaml (repo_shortname, project, app, function)
- Update local.yaml env->environment for consistency
- Refactor oidc-validate to use local action references
- Add backend summary echo for AWS validation
- Update CODEOWNERS for infrastructure/config governance
- All actions now use local paths for self-contained testing