### PR TITLE
refactor: bootstrap Terraform env and simplify Azure network pipeline

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+export TF_VAR_global_config_path="$PWD/infrastructure/config/globals.yaml"
+export TF_VAR_env_config_path="$PWD/config/envs/dev.yaml"
+export TF_BACKEND_CONFIG_FILE="$PWD/infrastructure/environment/dev/backend/backend-config.json"
+

--- a/.github/actions/bootstrap-env/action.yml
+++ b/.github/actions/bootstrap-env/action.yml
@@ -1,0 +1,20 @@
+name: "Bootstrap Environment"
+description: "Export Terraform config and backend paths for workflows"
+
+inputs:
+  env:
+    description: "Environment name (e.g., dev)"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Export config paths
+      shell: bash
+      run: |
+        set -euo pipefail
+        REPO_ROOT="$GITHUB_WORKSPACE"
+        echo "TF_VAR_global_config_path=$REPO_ROOT/infrastructure/config/globals.yaml" >> "$GITHUB_ENV"
+        echo "TF_VAR_env_config_path=$REPO_ROOT/config/envs/${{ inputs.env }}.yaml" >> "$GITHUB_ENV"
+        BACKEND_FILE="$REPO_ROOT/infrastructure/environment/${{ inputs.env }}/backend/backend-config.json"
+        echo "TF_BACKEND_CONFIG_FILE=$BACKEND_FILE" >> "$GITHUB_ENV"

--- a/.github/workflows/azure-network.yml
+++ b/.github/workflows/azure-network.yml
@@ -43,6 +43,11 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: eu-west-1
 
+      - name: Bootstrap environment
+        uses: ./.github/actions/bootstrap-env
+        with:
+          env: dev
+
       # --- BACKEND: create/ensure S3+DDB and write backend-config.json ---
       - name: Terraform Backend (AWS)
         uses: ./.github/actions/terraform-backend
@@ -67,12 +72,12 @@ jobs:
         with:
           working-directory: infrastructure/environment/azure/network
           terraform-version: 1.13.2
-          backend-config-file: infrastructure/environment/dev/backend/backend-config.json
+          backend-config-file: ${{ env.TF_BACKEND_CONFIG_FILE }}
 
       # Plan / Apply (use your config files; fix path if it's 'globals.yaml' not 'global.yaml')
       - name: Terraform plan
         working-directory: infrastructure/environment/azure/network
-        run: terraform plan -var="global_config_path=infrastructure/config/globals.yaml" -var="env_config_path=config/envs/dev.yaml" -out=tfplan
+        run: terraform plan -out=tfplan
 
       - name: Terraform apply
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -102,5 +102,5 @@ temp/
 
 # CI/CD generated artifacts
 infrastructure/environment/*/backend/backend-config.json
+infrastructure/environment/*/backend/
 infrastructure/environment/*/artifacts/
-infrastructure/environment/*/artifacts/**/*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+TF_DIR ?= infrastructure/environment/azure/network
+TF_BACKEND_CONFIG_FILE ?= infrastructure/environment/dev/backend/backend-config.json
+
+.PHONY: init plan apply
+
+init:
+	terraform -chdir=$(TF_DIR) init -backend-config=$(TF_BACKEND_CONFIG_FILE)
+
+plan: init
+	terraform -chdir=$(TF_DIR) plan -out=tfplan
+
+apply: init
+	terraform -chdir=$(TF_DIR) apply -auto-approve tfplan
+

--- a/infrastructure/environment/azure/network/locals.tf
+++ b/infrastructure/environment/azure/network/locals.tf
@@ -1,19 +1,17 @@
 variable "global_config_path" {
   description = "Path to global config file"
   type        = string
-  default     = "config/global.yaml"
 }
 
 variable "env_config_path" {
   description = "Path to environment config file"
   type        = string
-  default     = "config/envs/dev.yaml"
 }
 
 locals {
   # Load config files
-  global_config = yamldecode(file("${path.module}/../../../${var.global_config_path}"))
-  env_config    = yamldecode(file("${path.module}/../../../${var.env_config_path}"))
+  global_config = yamldecode(file(var.global_config_path))
+  env_config    = yamldecode(file(var.env_config_path))
 
   # Azure configuration with fallbacks
   az = {


### PR DESCRIPTION
## Summary
- add composite bootstrap action exporting config paths and backend file
- refactor azure-network workflow and locals to rely on TF_VARs rather than -var flags
- add local dev parity files (.envrc, Makefile) and ignore generated backend artifacts

## Testing
- `terraform fmt -recursive` *(fails: command not found)*
- `make plan` *(fails: terraform: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c49bfc46fc8325bfddbca7ef869527