### PR TITLE
Improve external-dns AWS credential handling

### DIFF
--- a/infrastructure/addons/plugins/external-dns/install.sh
+++ b/infrastructure/addons/plugins/external-dns/install.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 PLUGIN_NAME="external-dns"
 PLUGIN_DIR="$(dirname "$0")"
 NAMESPACE="external-dns-system"
+AWS_AUTH_MODE=""
+AWS_CREDENTIALS_SECRET_NAME="${AWS_CREDENTIALS_SECRET_NAME:-external-dns-aws-credentials}"
 
 echo "🚀 Installing plugin: $PLUGIN_NAME"
 echo "Environment: $ENVIRONMENT"
@@ -29,6 +31,18 @@ validate_config() {
     # Validate cloud-specific requirements
     if [[ "$CLOUD_PROVIDER" == "aws" ]]; then
         check_env_var "AWS_REGION" "AWS region must be specified"
+
+        if [[ -n "${AWS_ROLE_ARN:-}" ]]; then
+            AWS_AUTH_MODE="oidc"
+            echo "✅ Using AWS IAM role via web identity"
+        elif [[ -n "${AWS_ACCESS_KEY_ID:-}" && -n "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+            AWS_AUTH_MODE="static"
+            echo "✅ Using static AWS credentials"
+        else
+            echo "❌ Either AWS_ROLE_ARN or AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY must be provided for AWS deployments"
+            exit 1
+        fi
+
         echo "✅ AWS configuration validated"
     elif [[ "$CLOUD_PROVIDER" == "azure" ]]; then
         check_env_var "AZURE_SUBSCRIPTION_ID" "Azure subscription ID must be specified"
@@ -68,6 +82,38 @@ prepare_values() {
     
     # Process template variables
     envsubst < "$values_file" > "$temp_values"
+
+    if [[ "$CLOUD_PROVIDER" == "aws" ]]; then
+        if [[ "$AWS_AUTH_MODE" == "oidc" ]]; then
+            cat <<EOF >> "$temp_values"
+
+extraEnv:
+  - name: AWS_REGION
+    value: "${AWS_REGION}"
+  - name: AWS_ROLE_ARN
+    value: "${AWS_ROLE_ARN}"
+  - name: AWS_WEB_IDENTITY_TOKEN_FILE
+    value: "${AWS_WEB_IDENTITY_TOKEN_FILE:-/var/run/secrets/eks.amazonaws.com/serviceaccount/token}"
+EOF
+        elif [[ "$AWS_AUTH_MODE" == "static" ]]; then
+            cat <<EOF >> "$temp_values"
+
+extraEnv:
+  - name: AWS_REGION
+    value: "${AWS_REGION}"
+  - name: AWS_ACCESS_KEY_ID
+    valueFrom:
+      secretKeyRef:
+        name: ${AWS_CREDENTIALS_SECRET_NAME}
+        key: aws-access-key-id
+  - name: AWS_SECRET_ACCESS_KEY
+    valueFrom:
+      secretKeyRef:
+        name: ${AWS_CREDENTIALS_SECRET_NAME}
+        key: aws-secret-access-key
+EOF
+        fi
+    fi
     
     echo "✅ Values file prepared: $temp_values"
     echo "Values content:"
@@ -84,13 +130,22 @@ install_plugin() {
     echo "Adding Helm repository..."
     helm repo add external-dns https://kubernetes-sigs.github.io/external-dns/
     helm repo update
-    
+
     # Create namespace if it doesn't exist
     kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
-    
+
     # Label namespace for management
     kubectl label namespace "$NAMESPACE" app.kubernetes.io/managed-by=plugin-manager --overwrite
     kubectl label namespace "$NAMESPACE" app.kubernetes.io/name=external-dns --overwrite
+
+    if [[ "$CLOUD_PROVIDER" == "aws" && "$AWS_AUTH_MODE" == "static" ]]; then
+        kubectl create secret generic "$AWS_CREDENTIALS_SECRET_NAME" \
+            --namespace "$NAMESPACE" \
+            --from-literal=aws-access-key-id="$AWS_ACCESS_KEY_ID" \
+            --from-literal=aws-secret-access-key="$AWS_SECRET_ACCESS_KEY" \
+            --dry-run=client -o yaml | kubectl apply -f -
+        echo "✅ AWS credentials secret configured: $AWS_CREDENTIALS_SECRET_NAME"
+    fi
     
     # Install with Helm
     echo "Installing External DNS with Helm..."
@@ -187,6 +242,9 @@ main() {
     echo "📋 Installation Summary:"
     echo "  Namespace: $NAMESPACE"
     echo "  Cloud Provider: $CLOUD_PROVIDER"
+    if [[ "$CLOUD_PROVIDER" == "aws" ]]; then
+        echo "  AWS Auth Mode: $AWS_AUTH_MODE"
+    fi
     echo "  Domain Filters: $DOMAIN_FILTERS"
     echo "  TXT Owner ID: $TXT_OWNER_ID"
     echo ""


### PR DESCRIPTION
## Summary
- validate that either an IAM role or static AWS credentials are provided when installing the external-dns plugin on AWS
- append the appropriate AWS environment configuration to the rendered Helm values and surface the selected authentication mode in the summary output
- automatically create/update the Kubernetes secret for static credentials so the deployment can mount them safely

## Testing
- bash -n infrastructure/addons/plugins/external-dns/install.sh

------
https://chatgpt.com/codex/tasks/task_e_68cb83a1d6c4832583f71ca20c61dae0