### PR TITLE
Refine external-dns AWS credential injection

### DIFF
--- a/infrastructure/addons/plugins/external-dns/values/aws.yaml
+++ b/infrastructure/addons/plugins/external-dns/values/aws.yaml
@@ -18,6 +18,7 @@ aws:
   batchChangeSize: 1000
   batchChangeInterval: 1s
   evaluateTargetHealth: true
+${AWS_CREDENTIAL_SETTINGS:-}
 
 # Domain configuration
 domainFilters: 
@@ -107,6 +108,8 @@ extraArgs:
   - --aws-batch-change-size=1000
   - --aws-batch-change-interval=1s
   - --aws-evaluate-target-health
+
+${AWS_ENV_BLOCK:-}
 
 # Node selector and tolerations
 nodeSelector: {}


### PR DESCRIPTION
## Summary
- template AWS credential-related YAML fragments before rendering Helm values
- embed dynamic environment variable and credential settings directly into the generated values file

## Testing
- bash -n infrastructure/addons/plugins/external-dns/install.sh
- shellcheck infrastructure/addons/plugins/external-dns/install.sh *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cb83a1d6c4832583f71ca20c61dae0